### PR TITLE
Better function calls 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "scripts": {
         "check": [
+            "vendor\\bin\\phpcbf.bat src/ --standard=ruleset.xml",
             "vendor\\bin\\phpcs.bat src/ --standard=ruleset.xml -n",
             "vendor\\bin\\phpunit.bat tests/"
         ]

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
            "psr-4": {
                 "Hulk\\": "src/",
                 "Hulk\\Core\\": "src/core/"
-            }
+            },
+            "files": ["src/autoloader.php"]
     },
     "scripts": {
         "check": [

--- a/src/Hulk.php
+++ b/src/Hulk.php
@@ -51,6 +51,6 @@ class Hulk
             self::$heart = new Core\Heart();
             self::$initialized = true;
         }
-        return self::$heart->captain->run($name, $params);
+        return self::$heart->captain->invoke([self::$heart, $name], $params);
     }
 }

--- a/src/Hulk.php
+++ b/src/Hulk.php
@@ -51,6 +51,6 @@ class Hulk
             self::$heart = new Core\Heart();
             self::$initialized = true;
         }
-        return self::$heart->captain->run([self::$heart, $name], $params);
+        return self::$heart->captain->run($name, $params);
     }
 }

--- a/src/autoloader.php
+++ b/src/autoloader.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__.'/core/Loader.php';
+Hulk\core\Loader::autoload();

--- a/src/core/Captain.php
+++ b/src/core/Captain.php
@@ -10,16 +10,46 @@ namespace Hulk\Core;
  */
 class Captain
 {
+
+    private $calls = [];
+
     /**
      * Run a specified function
      * @param  Mixed $name   Name of the function
      * @param  Mixed $params Params to pass
-     * 
+     *
      * @return Mixed         Result of function
      */
     public function run($name, $params)
     {
-        return $this->invoke($name, $params);
+        return $this->invoke($this->get($name), $params);
+    }
+
+    /**
+     * Set Class/Function information for a function
+     * @param String $name     Name of function
+     * @param Array  $callback Array with Class/Function information
+     *
+     * @return Null  Nothing
+     */
+    public function set($name, $callback)
+    {
+        $this->calls[$name] = $callback;
+    }
+
+    /**
+     * Get Class/Function information for a Function
+     * @param  String $name Name of function
+     *
+     * @return Array        Array with Class/Function information
+     */
+    public function get($name)
+    {
+        if (isset($this->calls[$name])) {
+            return $this->calls[$name];
+        } else {
+            throw new HulkException("Function {$name} not found.");
+        };
     }
 
     /**

--- a/src/core/Captain.php
+++ b/src/core/Captain.php
@@ -48,7 +48,7 @@ class Captain
         if (isset($this->calls[$name])) {
             return $this->calls[$name];
         } else {
-            throw new HulkException("Function {$name} not found.");
+            return null;
         };
     }
 
@@ -60,7 +60,7 @@ class Captain
      * @return Mixed         Result of function
      * @throws Hulk\Core\HulkException
      */
-    private function invoke($name, $params)
+    public function invoke($name, $params)
     {
         if (is_callable($name)) {
             return call_user_func_array($name, $params);

--- a/src/core/Heart.php
+++ b/src/core/Heart.php
@@ -28,6 +28,8 @@ class Heart
      */
     public function __construct()
     {
+        $this->captain = new Captain();
+
         $this->build();
     }
 
@@ -46,14 +48,16 @@ class Heart
         $this->set('hulk.exceptions', true);
         $this->set('hulk.errors', true);
 
-        $this->captain = new Captain();
+        foreach (['smash', 'set', 'get', 'clear', 'has', 'delete'] as $key) {
+            $this->captain->set($key, [$this, $key]);
+        }
 
         $this->buildEHandlers();
     }
 
     /**
      * Start function
-     * 
+     *
      * @return null nothing
      */
     public static function smash()

--- a/src/core/Heart.php
+++ b/src/core/Heart.php
@@ -34,6 +34,14 @@ class Heart
         $this->build();
     }
 
+    /**
+     * Handles functions calls
+     *
+     * @param  String $name   Name of function or class
+     * @param  Array  $params Params
+     *
+     * @return Mixed          Return of functions
+     */
     public function __call($name, $params)
     {
         if (is_callable($this->captain->get($name))) {
@@ -75,13 +83,30 @@ class Heart
         print "test";
     }
 
-    public function path($path){
+    /**
+     * Add path to autoloader
+     * @param  String $path Path to Directory
+     *
+     * @return null         nothing
+     */
+    public function path($path)
+    {
         $this->loader->addDirectory($path);
     }
 
-    public function register($name, $class, $params = []){
+    /**
+     * Register class
+     * @param  String $name   Name to run class
+     * @param  String $class  Name of class
+     * @param  Array  $params Params for instantiation
+     *
+     * @return null           nothing
+     */
+    public function register($name, $class, $params = [])
+    {
         $this->loader->register($name, $class, $params);
     }
+
     /**
      * Sets a variable to save in the framework
      *

--- a/src/core/Heart.php
+++ b/src/core/Heart.php
@@ -29,8 +29,18 @@ class Heart
     public function __construct()
     {
         $this->captain = new Captain();
+        $this->loader = new Loader();
 
         $this->build();
+    }
+
+    public function __call($name, $params)
+    {
+        if (is_callable($this->captain->get($name))) {
+            return $this->$captain->run($name, $params);
+        } else {
+            return $this->loader->run($name);
+        }
     }
 
     /**
@@ -48,7 +58,7 @@ class Heart
         $this->set('hulk.exceptions', true);
         $this->set('hulk.errors', true);
 
-        foreach (['smash', 'set', 'get', 'clear', 'has', 'delete'] as $key) {
+        foreach (['smash', 'set', 'get', 'clear', 'has', 'delete', 'register', 'path'] as $key) {
             $this->captain->set($key, [$this, $key]);
         }
 
@@ -65,6 +75,13 @@ class Heart
         print "test";
     }
 
+    public function path($path){
+        $this->loader->addDirectory($path);
+    }
+
+    public function register($name, $class, $params = []){
+        $this->loader->register($name, $class, $params);
+    }
     /**
      * Sets a variable to save in the framework
      *

--- a/src/core/Heart.php
+++ b/src/core/Heart.php
@@ -53,6 +53,7 @@ class Heart
 
     /**
      * Start function
+     * 
      * @return null nothing
      */
     public static function smash()

--- a/src/core/Loader.php
+++ b/src/core/Loader.php
@@ -35,21 +35,31 @@ class Loader
     /**
      * Register a class
      *
+     * @param  String $name   Name to run class
+     * @param  String $class  Name of class
+     * @param  Array  $params Params for instantiation
+     *
      * @return null
      */
-     public function register($name, $class, array $params = [])
-     {
-         unset($this->instances[$name]);
-         $this->classes[$name] = array($class, $params);
-     }
+    public function register($name, $class, array $params = [])
+    {
+        unset($this->instances[$name]);
+        $this->classes[$name] = array($class, $params);
+    }
 
-     public function run($class)
-     {
+    /**
+     * Get a class
+     * @param  String $class Name to run class
+     * @return Object        Class
+     */
+    public function run($class)
+    {
         $return = null;
+
         if (isset($this->classes[$class])) {
             list($class, $params) = $this->classes[$class];
-            if(isset($this->instances[$class]))
-            {
+
+            if (isset($this->instances[$class])) {
                 $return = $this->getInstance($class);
             } else {
                 $return = $this->newInstance($class, $params);
@@ -57,10 +67,10 @@ class Loader
             }
 
             return $return;
-        }else{
+        } else {
             throw new HulkException("No class found with name {$class}");
         }
-     }
+    }
 
     /**
      * Unregister a class
@@ -74,6 +84,7 @@ class Loader
 
     /**
      * Get instance of class if doesnt exist create new one
+     * @param String $class name fo class
      *
      * @return null
      */
@@ -82,6 +93,12 @@ class Loader
         return isset($this->instances[$class]) ? $this->instances[$class] : null;
     }
 
+    /**
+     * Get a new instance
+     * @param  String $class  Name of class
+     * @param  Array  $params Array to instance class
+     * @return Object        New class
+     */
     public function newInstance($class, $params = null)
     {
         return (new \ReflectionClass($class))->newInstanceArgs($params);
@@ -92,13 +109,14 @@ class Loader
      *
      * @return null
      */
-    public function autoload()
+    public static function autoload()
     {
         spl_autoload_register(array(__CLASS__, 'load'));
     }
 
     /**
      * Used by autoloader to load classes.
+     * @param String $name Class to load
      *
      * @return null
      */
@@ -107,20 +125,28 @@ class Loader
         foreach (self::$dirs as $dir) {
             $file = $dir.'/'.$name.'.php';
             if (file_exists($file)) {
-                require $file;
+                include $file;
                 return;
             }
         }
     }
 
-    public static function addDirectory($dir) {
+    /**
+     * Add directory to autoloader
+     * @param String $dir Directory to autoload
+     *
+     * @return null       nothing
+     */
+    public static function addDirectory($dir)
+    {
         if (is_array($dir) || is_object($dir)) {
             foreach ($dir as $value) {
                 self::addDirectory($value);
             }
-        }
-        else if (is_string($dir)) {
-            if (!in_array($dir, self::$dirs)) self::$dirs[] = $dir;
+        } elseif (is_string($dir)) {
+            if (!in_array($dir, self::$dirs)) {
+                self::$dirs[] = $dir;
+            }
         }
     }
 }


### PR DESCRIPTION
It's now possible to add any path to autoloading with:
```php
Hulk\Hulk::path('foo/');
```
to add a class to the framework use the command:
```php
Hulk\Hulk::register('name', 'className', ['params']);
```
Now it's possible to get this class with:
```php
$class = Hulk\Hulk::name();
```
or run functions directly
```php
Hulk\Hulk::name()->myFunc();
```